### PR TITLE
Serialization tests

### DIFF
--- a/beacon_chain/utils/simpleserialize.py
+++ b/beacon_chain/utils/simpleserialize.py
@@ -1,3 +1,6 @@
+import collections
+
+
 def serialize(val, typ=None):
     if typ is None and hasattr(val, 'fields'):
         typ = type(val)
@@ -62,11 +65,15 @@ def deserialize(data, typ):
 
 def eq(x, y):
     if hasattr(x, 'fields') and hasattr(y, 'fields'):
+        if x.fields != y.fields:
+            return False
         for f in x.fields:
             if not eq(getattr(x, f), getattr(y, f)):
                 print('Unequal:', x, y, f, getattr(x, f), getattr(y, f))
                 return False
-            return True
+        return True
+    elif isinstance(x, collections.Iterable) and isinstance(y, collections.Iterable):
+        return all(eq(xi, yi) for xi, yi in zip(x, y))
     else:
         return x == y
 

--- a/tests/utils/test_serialization.py
+++ b/tests/utils/test_serialization.py
@@ -10,6 +10,7 @@ from beacon_chain.utils.simpleserialize import (
     serialize,
     deserialize,
     eq,
+    to_dict,
 )
 
 
@@ -26,6 +27,33 @@ from beacon_chain.utils.simpleserialize import (
 def test_basic_serialization(value, typ, data):
     assert serialize(value, typ) == data
     assert deserialize(data, typ) == value
+
+
+@pytest.mark.parametrize(
+    'value, typ',
+    [
+        (b'', 'byte'),
+        (b'', 'hash16'),
+        (0, 0),
+    ]
+)
+def test_failed_serialization(value, typ):
+    with pytest.raises(Exception):
+        serialize(value, typ)
+
+
+@pytest.mark.parametrize(
+    'data, typ',
+    [
+        (b'randombytes', 'hash31'),
+        (b'randombytes', 'bytes32'),
+        (b'randombytes', 'unknown'),
+        (b'randombytes', ['unknown']),
+    ]
+)
+def test_deserialization_unknown_type(data, typ):
+    with pytest.raises(Exception):
+        deserialize(data, typ)
 
 
 def test_active_state_serialization():
@@ -47,3 +75,72 @@ def test_active_state_serialization():
     )
     ds = deserialize(serialize(s, type(s)), type(s))
     assert eq(s, ds)
+
+
+@pytest.mark.parametrize(
+    'value, result',
+    [
+        ({}, {}),
+        ({'a': 1, 'b': 2}, {'a': 1, 'b': 2}),
+        ([], []),
+        ([{'a': 1}, {'b': 2}], [{'a': 1}, {'b': 2}])
+    ]
+)
+def test_to_dict(value, result):
+    assert to_dict(value) == result
+
+
+@pytest.mark.parametrize(
+    'field_data',
+    [
+        [],
+        [('a', 'int64', 1), ('b', 'hash32', b'two')]
+    ]
+)
+def test_object_to_dict(field_data):
+    class O:
+        fields = {name: typ for name, typ, _ in field_data}
+        defaults = {name: value for name, _, value in field_data}
+
+    o = O()
+    for name, _, value in field_data:
+        setattr(o, name, value)
+
+    assert to_dict(o) == {name: value for name, _, value in field_data}
+
+
+@pytest.mark.parametrize(
+    'left_fields, right_fields, equal',
+    [
+        [[], [], True],
+        [[('a', 'int64', 0)], [('a', 'int64', 0)], True],
+        [
+            [('a', 'int64', 0), ('b', 'hash32', b'\x00' * 32)],
+            [('a', 'int64', 0), ('b', 'hash32', b'\x00' * 32)],
+            True
+        ],
+        [[('a', 'int64', 0)], [], False],
+        [[('a', 'int64', 0)], [('a', 'int64', 1)], False],  # different value
+        [[('a', 'int64', 0)], [('a', 'int32', 0)], False],  # different type
+        [[('a', 'int64', 0)], [('b', 'int64', 0)], False],  # different name
+    ]
+)
+def test_eq(left_fields, right_fields, equal):
+    class LeftClass:
+        fields = {name: typ for name, typ, _ in left_fields}
+        defaults = {name: value for name, _, value in left_fields}
+
+    class RightClass:
+        fields = {name: typ for name, typ, _ in right_fields}
+        defaults = {name: value for name, _, value in right_fields}
+
+    left_object = LeftClass()
+    for name, _, value in left_fields:
+        setattr(left_object, name, value)
+
+    right_object = RightClass()
+    for name, _, value in right_fields:
+        setattr(right_object, name, value)
+
+    assert eq(left_object, right_object) == equal
+    assert eq(right_object, left_object) == equal


### PR DESCRIPTION
- added some tests for simpleserialize.py (see #15)
- fixed a couple of small bugs in `eq`:
  - additional fields on the second argument compared to the first one were ignored
  - only the first field was checked due to wrong indentation of return statement
  - lists of objects were not handled correctly
  - objects whose attributes have the same values but different types were considered equal

I guess the last point is debatable, let me know if you want me to remove the check.