### PR TITLE
fix #19 Add Circle ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/python:3.6.1
+      - image: circleci/python:3.6
 
     working_directory: ~/repo
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,41 @@
+# Python CircleCI 2.0 configuration file
+#
+# Check https://circleci.com/docs/2.0/language-python/ for more details
+#
+version: 2
+jobs:
+  build:
+    docker:
+      - image: circleci/python:3.6.1
+
+    working_directory: ~/repo
+
+    steps:
+      - checkout
+
+      # Download and cache dependencies
+      - restore_cache:
+          keys:
+          - v1-dependencies-{{ checksum "requirements.txt" }}
+          # fallback to using the latest cache if no exact match is found
+          - v1-dependencies-
+
+      - run:
+          name: install dependencies
+          command: |
+            python3 -m venv venv
+            . venv/bin/activate
+            pip install -r requirements.txt
+
+      - save_cache:
+          paths:
+            - ./venv
+          key: v1-dependencies-{{ checksum "requirements.txt" }}
+
+      - run:
+          name: run tests
+          command: |
+            . venv/bin/activate
+            pytest tests
+
+          

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,6 +36,11 @@ jobs:
           name: run tests
           command: |
             . venv/bin/activate
-            pytest tests
+            mkdir test-reports
+            pytest tests --junitxml=test-reports/junit.xml
 
-          
+      - store_test_results:
+          path: test-reports
+
+      - store_artifacts:
+          path: test-reports

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 venv
 .DS_Store
 .pytest_cache
+test-reports/

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # eth2.0 Beacon Chain
+[![CircleCI](https://circleci.com/gh/ethereum/beacon_chain.svg?style=svg)](https://circleci.com/gh/ethereum/beacon_chain)
 > Implements a proof of concept beacon chain for a sharded pos ethereum 2.0. Spec in progress can be found [here](https://notes.ethereum.org/SCIg8AH5SA-O4C1G1LYZHQ?view).
 
 ## Installation


### PR DESCRIPTION
This might need some project configuration:

1. setting up `etherum/beacon_chain` project on https://circleci.com . This should also add the pull requests webhook to Github.