### PR TITLE
Add tests for block class

### DIFF
--- a/tests/state/test_block.py
+++ b/tests/state/test_block.py
@@ -1,0 +1,47 @@
+from beacon_chain.state.block import (
+    Block,
+)
+from beacon_chain.utils.bls import (
+    privtopub,
+)
+
+
+def test_block_signing():
+    block = Block()
+    privkey = 1
+    pubkey = privtopub(privkey)
+
+    assert not block.verify(pubkey)
+
+    block.sign(1)
+    assert block.sig != [0, 0]
+    assert block.verify(privtopub(1))
+
+    block.sign(2)
+    assert not block.verify(privtopub(1))
+    assert block.verify(privtopub(2))
+
+    block.skip_count = 1
+    assert not block.verify(privtopub(2))
+
+
+def test_block_hash():
+    block = Block()
+    original_block_hash = block.hash
+
+    assert original_block_hash != b'\x00' * 32
+    assert len(original_block_hash) == 32
+
+    block.sign(1)
+    signed_block_hash_1 = block.hash
+    assert signed_block_hash_1 != original_block_hash
+    block.sign(2)
+    signed_block_hash_2 = block.hash
+    assert signed_block_hash_2 != original_block_hash
+    assert signed_block_hash_2 != signed_block_hash_1
+
+    block = Block(skip_count=1)
+    assert block.hash != original_block_hash
+    assert block.hash != signed_block_hash_1
+    assert block.hash != signed_block_hash_2
+


### PR DESCRIPTION
Simple tests for block signing and hashing.

One thing that stood out to me is that the block signature is included in the hash which is different to Ethereum 1.0 behavior. Is this intentional? It doesn't seem to break anything because the hash isn't used to calculate the signature, but I wanted to ask anyway just to be sure.