### PR TITLE
mock bls in state tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 eth-tester[py-evm]==0.1.0b29
 py-ecc==1.4.3
 pytest==3.6.1
+pytest-mock==1.10.0
 web3==4.3.0
 eth-vyper==0.1.0b3
 # for Python versions older than Python 3.6

--- a/tests/state/conftest.py
+++ b/tests/state/conftest.py
@@ -42,7 +42,8 @@ from beacon_chain.state.helpers import (
     get_crosslink_notaries,
 )
 
-import beacon_chain.utils.bls as bls
+
+import beacon_chain.utils.bls
 from beacon_chain.utils.bitfield import (
     get_empty_bitfield,
     set_voted,
@@ -54,10 +55,29 @@ from beacon_chain.utils.simpleserialize import (
     serialize,
 )
 
+bls = beacon_chain.utils.bls
 
 DEFAULT_SHUFFLING_SEED = b'\35'*32
 DEFAULT_RANDAO = b'\45'*32
 DEFAULT_NUM_VALIDATORS = 40
+
+
+def bls_verify_mock(m, pub, sig):
+    return True
+
+
+def bls_sign_mock(m, k):
+    return 0, 0
+
+
+@pytest.fixture(autouse=True)
+def mock_bls_verify(mocker):
+    mocker.patch('beacon_chain.utils.bls.verify', side_effect=bls_verify_mock)
+
+
+@pytest.fixture(autouse=True)
+def mock_bls_sign(mocker):
+    mocker.patch('beacon_chain.utils.bls.sign', side_effect=bls_sign_mock)
 
 
 @pytest.fixture
@@ -350,3 +370,6 @@ def mock_make_child(keymap, make_unfinished_block, config):
 
         return block, new_crystallized_state, new_active_state
     return mock_make_child
+
+
+

--- a/tests/state/conftest.py
+++ b/tests/state/conftest.py
@@ -71,12 +71,8 @@ def bls_sign_mock(m, k):
 
 
 @pytest.fixture(autouse=True)
-def mock_bls_verify(mocker):
+def mock_bls(mocker):
     mocker.patch('beacon_chain.utils.bls.verify', side_effect=bls_verify_mock)
-
-
-@pytest.fixture(autouse=True)
-def mock_bls_sign(mocker):
     mocker.patch('beacon_chain.utils.bls.sign', side_effect=bls_sign_mock)
 
 
@@ -370,6 +366,3 @@ def mock_make_child(keymap, make_unfinished_block, config):
 
         return block, new_crystallized_state, new_active_state
     return mock_make_child
-
-
-


### PR DESCRIPTION
- mock bls `sign` and `verify` in state tests
- reduces time from `> 1 minute` to `~15 seconds`
- The timing logging in `test_full_pos.py` becomes meaningless