### PR TITLE
testing env: bump eth-tester and vyper

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,8 +17,6 @@ jobs:
       - restore_cache:
           keys:
           - v1-dependencies-{{ checksum "requirements.txt" }}
-          # fallback to using the latest cache if no exact match is found
-          - v1-dependencies-
 
       - run:
           name: install dependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
       # Download and cache dependencies
       - restore_cache:
           keys:
-          - v1-dependencies-{{ checksum "requirements.txt" }}
+          - cache-{{.Environment.CIRCLE_JOB}}-{{ checksum "requirements.txt" }}
 
       - run:
           name: install dependencies
@@ -28,7 +28,7 @@ jobs:
       - save_cache:
           paths:
             - ./venv
-          key: v1-dependencies-{{ checksum "requirements.txt" }}
+          key: cache-{{.Environment.CIRCLE_JOB}}-{{ checksum "requirements.txt" }}
 
       - run:
           name: run tests

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,7 @@
-eth-tester==0.1.0b29
+eth-tester[py-evm]==0.1.0b29
 py-ecc==1.4.3
 pytest==3.6.1
 web3==4.3.0
-git+https://github.com/ethereum/vyper.git@v0.1.0-beta.1
-
+eth-vyper==0.1.0b3
 # for Python versions older than Python 3.6
 pyblake2==1.1.2 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-eth-tester==0.1.0b27
+eth-tester==0.1.0b29
 py-ecc==1.4.3
 pytest==3.6.1
 web3==4.3.0


### PR DESCRIPTION
To fix the CI:
1. Bump `eth-tester` to `0.1.0b29`. (`evm` -> `eth`)
2. Bump `vyper` to `0.1.0b3`

I think CircleCI looks fine only because it uses the cache. Also updated the CircleCI config.