### PR TITLE
add slot field to crosslink and update when required

### DIFF
--- a/beacon_chain/state/crosslink_record.py
+++ b/beacon_chain/state/crosslink_record.py
@@ -8,12 +8,15 @@ class CrosslinkRecord():
     fields = {
         # What dynasty the crosslink was submitted in
         'dynasty': 'int64',
+        # slot during which crosslink was added
+        'slot': 'int64',
         # The block hash
-        'hash': 'hash32'
+        'hash': 'hash32',
     }
     defaults = {
         'dynasty': 0,
-        'hash': b'\x00'*32
+        'slot': 0,
+        'hash': b'\x00'*32,
     }  # type: Dict[str, Any]
 
     def __init__(self, **kwargs):

--- a/beacon_chain/state/genesis_helpers.py
+++ b/beacon_chain/state/genesis_helpers.py
@@ -64,7 +64,7 @@ def get_genesis_crystallized_state(
         current_dynasty=current_dynasty,
         crosslinking_start_shard=crosslinking_start_shard,
         crosslink_records=[
-            CrosslinkRecord(hash=ZERO_HASH32, dynasty=0)
+            CrosslinkRecord(hash=ZERO_HASH32, slot=0, dynasty=0)
             for i
             in range(config['shard_count'])
         ],

--- a/beacon_chain/state/state_transition.py
+++ b/beacon_chain/state/state_transition.py
@@ -30,14 +30,8 @@ from .config import (
 from .active_state import (
     ActiveState,
 )
-from .attestation_record import (
-    AttestationRecord,
-)
 from .crosslink_record import (
     CrosslinkRecord,
-)
-from .block import (
-    Block,
 )
 from .crystallized_state import (
     CrystallizedState,
@@ -54,7 +48,7 @@ if TYPE_CHECKING:
     from .block import Block  # noqa: F401
 
 
-def validate_block(block: Block) -> bool:
+def validate_block(block: 'Block') -> bool:
     # ensure parent processed
     # ensure pow_chain_ref processed
     # ensure local time is large enough to process this block's slot
@@ -64,8 +58,8 @@ def validate_block(block: Block) -> bool:
 
 def validate_attestation(crystallized_state: CrystallizedState,
                          active_state: ActiveState,
-                         attestation: AttestationRecord,
-                         block: Block,
+                         attestation: 'AttestationRecord',
+                         block: 'Block',
                          config: Dict[str, Any]=DEFAULT_CONFIG) -> None:
     if not attestation.slot < block.slot_number:
         raise Exception("Attestation slot number too high")
@@ -192,7 +186,7 @@ def process_block(crystallized_state: CrystallizedState,
 
 def process_updated_crosslinks(crystallized_state: CrystallizedState,
                                active_state: ActiveState,
-                               block: Block,
+                               block: 'Block',
                                config: Dict[str, Any]=DEFAULT_CONFIG) -> List[CrosslinkRecord]:
     total_attestation_balance = {}  # type: Dict[Tuple[ShardId, Hash32], int]
 
@@ -226,7 +220,7 @@ def process_updated_crosslinks(crystallized_state: CrystallizedState,
                 crystallized_state.current_dynasty > crosslinks[attestation.shard_id].dynasty):
             crosslinks[attestation.shard_id] = CrosslinkRecord(
                 dynasty=crystallized_state.current_dynasty,
-                slot=block.slot_number,  # TODO: this might be incorrect and is being checked
+                slot=block.slot_number,
                 hash=attestation.shard_block_hash
             )
     return crosslinks

--- a/tests/state/conftest.py
+++ b/tests/state/conftest.py
@@ -147,6 +147,7 @@ def sample_shard_and_committee_params():
 def sample_crosslink_record_params():
     return {
         'dynasty': 2,
+        'slot': 0,
         'hash': b'\x43'*32,
     }
 

--- a/tests/state/test_crosslink_record.py
+++ b/tests/state/test_crosslink_record.py
@@ -9,6 +9,7 @@ from beacon_chain.state.crosslink_record import (
     'param,default_value',
     [
         ('dynasty', 0),
+        ('slot', 0),
         ('hash', b'\x00'*32),
     ]
 )

--- a/tests/state/test_genesis_helpers.py
+++ b/tests/state/test_genesis_helpers.py
@@ -39,6 +39,10 @@ def test_get_genesis_crystallized_state(genesis_validators,
     assert crystallized_state.current_dynasty == 1
     assert crystallized_state.crosslinking_start_shard == 0
     assert len(crystallized_state.crosslink_records) == config['shard_count']
+    for crosslink in crystallized_state.crosslink_records:
+        assert crosslink.hash == ZERO_HASH32
+        assert crosslink.slot == 0
+        assert crosslink.dynasty == 0
     assert crystallized_state.total_deposits == total_deposits
     assert crystallized_state.dynasty_seed == init_shuffling_seed
     assert crystallized_state.dynasty_seed_last_reset == 1


### PR DESCRIPTION
addresses #82 

Note: the current Crosslink update function sets slot to `block.slot_number`, but this might change to be the cycle boundary instead of the block slot number.