### PR TITLE
resolve issue with parent_hashes being off by one

### DIFF
--- a/tests/state/conftest.py
+++ b/tests/state/conftest.py
@@ -38,8 +38,8 @@ from beacon_chain.state.genesis_helpers import (
     get_genesis_crystallized_state,
 )
 from beacon_chain.state.helpers import (
+    get_hashes_to_sign,
     get_new_shuffling,
-    get_signed_parent_hashes,
 )
 
 import beacon_chain.utils.bls
@@ -306,10 +306,9 @@ def mock_make_attestations(keymap, config):
             is_attesting[0] = True
 
             # Generating signatures and aggregating result
-            parent_hashes = get_signed_parent_hashes(
+            parent_hashes = get_hashes_to_sign(
                 active_state,
                 block,
-                attestation,
                 config
             )
             message = blake(


### PR DESCRIPTION
addresses #84 

- updated range in `get_signed_parent_hashes`
- introduced new function `get_hashes_to_sign`. This function must be used when constructing an attestation of a block (rather than verifying) because the hash of the block to be attested to is not yet in the `ActiveState.recent_block_hashes`. Take a look at the code. Happy to explain further.