### PR TITLE
fix(docker): copy files before pip install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
 FROM python:3.6-stretch
 
 WORKDIR /usr/src/app
-RUN pip install --upgrade setuptools
-RUN pip install -e .[dev] --no-cache-dir 
 
 COPY . .
+
+RUN pip install --upgrade setuptools
+RUN pip install -e .[dev] --no-cache-dir
 
 CMD [ "tail", "-f" "/dev/null" ]


### PR DESCRIPTION
### PROBLEM
```gherkin
Scenario: Docker build fails
Given I have just cloned the repo
When I run "make build"
Then I receive the error "Directory '.' is not installable. File 'setup.py' not found."
And the docker image does not build
```
- This is due to `pip install -e .[dev] --no-cache-dir ` failing because local modules referenced inside of `setup.py` are not available at installation time -- specifically `beacon_chain` and `ssz`.

### SOLUTION
```gherkin
Scenario: Add source files into the build image earlier
Given the problematic "Dockerfile" is
"""
FROM python:3.6-stretch

WORKDIR /usr/src/app

RUN pip install --upgrade setuptools
RUN pip install -e .[dev] --no-cache-dir

COPY . .

CMD [ "tail", "-f" "/dev/null" ]
"""
When I  move "COPY . ." before "pip install -e .[dev] --no-cache-dir"
Then pip can properly resolve "beacon_chain" and "ssz"
And "make build" runs successfully
```

### CUTE ANIMAL PICTURE? 😅
![tumblr_nhl0bb7kjx1qi4ucgo1_500](https://user-images.githubusercontent.com/183140/45650456-e7506580-bb00-11e8-852b-fab7bd26ea58.jpg)
