### PR TITLE
refactor(crystallized_state): calculate total_deposits dynamically

### DIFF
--- a/beacon_chain/state/state_transition.py
+++ b/beacon_chain/state/state_transition.py
@@ -246,6 +246,8 @@ def initialize_new_cycle(crystallized_state: CrystallizedState,
     last_justified_slot = crystallized_state.last_justified_slot
     last_finalized_slot = crystallized_state.last_finalized_slot
     justified_streak = crystallized_state.justified_streak
+    current_active_validator_indices = get_active_validator_indices(crystallized_state.current_dynasty, crystallized_state.validators)
+    current_total_deposits = sum(map(lambda i: crystallized_state.validators[i].balance, current_active_validator_indices))
     # walk through slots last_state_recalc - CYCLE_LENGTH ... last_state_recalc - 1
     # and check for justification, streaks, and finality
     for i in range(cycle_length):
@@ -257,7 +259,7 @@ def initialize_new_cycle(crystallized_state: CrystallizedState,
         else:
             vote_balance = 0
 
-        if 3 * vote_balance >= 2 * crystallized_state.total_deposits:
+        if 3 * vote_balance >= 2 * current_total_deposits:
             last_justified_slot = max(last_justified_slot, slot)
             justified_streak += 1
         else:


### PR DESCRIPTION
### CONTEXT
```gherkin
Scenario: Initialize new cycle
Given each validator must deposit "32 ETH"
And CYCLE_LENGTH is "64"
And DEFAULT_NUM_VALIDATORS is "40"
When a new cycle is initialised
Then total_deposits is calculated at "1280"
And justified_streak is calculated at "64"
```

- Current status ☝️

### NOTES

`vote_balance` and `total_deposits` are currently used to calculate `last_justified_slot` and `justified_streak`.

Some thing that is still unclear to me though is how much a validator have to stake for each cycle – can that be an arbitrary amount or is it always the full 32 ETH that was staked? The current tests for `initialize_new_cycle` suggest there could be a 3 ETH `total_deposit` which assumes the former.

- REF #104
- **Do not merge this PR yet, created for tracking and discussions.**