### PR TITLE
Fix ActiveState.chain maintenance and FFG rewards

### DIFF
--- a/beacon_chain/state/state_transition.py
+++ b/beacon_chain/state/state_transition.py
@@ -327,7 +327,8 @@ def initialize_new_cycle(crystallized_state: CrystallizedState,
         recent_block_hashes=active_state.recent_block_hashes[:],
         # Should probably clean up block_vote_cache but old records won't break cache
         # so okay for now
-        block_vote_cache=deepcopy(active_state.block_vote_cache)
+        block_vote_cache=deepcopy(active_state.block_vote_cache),
+        chain=deepcopy(active_state.chain),
     )
 
     return new_crystallized_state, new_active_state
@@ -344,7 +345,8 @@ def fill_recent_block_hashes(active_state: ActiveState,
             block.slot_number,
             block.parent_hash
         ),
-        block_vote_cache=deepcopy(active_state.block_vote_cache)
+        block_vote_cache=deepcopy(active_state.block_vote_cache),
+        chain=deepcopy(active_state.chain),
     )
 
 

--- a/beacon_chain/state/state_transition.py
+++ b/beacon_chain/state/state_transition.py
@@ -375,19 +375,19 @@ def calculate_ffg_rewards(crystallized_state: CrystallizedState,
         if block:
             block_hash = block.hash
             total_participated_deposits = block_vote_cache[block_hash]['total_voter_deposits']
-            voter_indices = block_vote_cache[block_hash]['total_voter_deposits']
+            voter_indices = block_vote_cache[block_hash]['voter_indices']
         else:
             total_participated_deposits = 0
             voter_indices = set()
 
-        participating_validator_indices = filter(
+        participating_validator_indices = list(filter(
             lambda index: index in voter_indices,
             active_validator_indices
-        )
-        non_participating_validator_indices = filter(
+        ))
+        non_participating_validator_indices = list(filter(
             lambda index: index not in voter_indices,
             active_validator_indices
-        )
+        ))
         # finalized recently?
         if time_since_finality <= 2 * config['cycle_length']:
             for index in participating_validator_indices:


### PR DESCRIPTION
1. Filled the missing `active_state.chain` maintenance during processing block
2. `voter_indices = block_vote_cache[block_hash]['total_voter_deposits']` -> `voter_indices = block_vote_cache[block_hash]['voter_indices']`