### PR TITLE
Added `justified_slot` and `justified_block_hash` validation

### DIFF
--- a/beacon_chain/state/state_transition.py
+++ b/beacon_chain/state/state_transition.py
@@ -122,7 +122,7 @@ def validate_attestation(crystallized_state: CrystallizedState,
                          attestation: 'AttestationRecord',
                          block: 'Block',
                          parent_block: 'Block',
-                         config: Dict[str, Any]=DEFAULT_CONFIG) -> None:
+                         config: Dict[str, Any]=DEFAULT_CONFIG) -> bool:
     #
     # validate slot number
     #

--- a/beacon_chain/state/state_transition.py
+++ b/beacon_chain/state/state_transition.py
@@ -136,9 +136,28 @@ def validate_attestation(crystallized_state: CrystallizedState,
             )
         )
 
-    # TODO: Verify that the justified_slot and justified_block_hash given are in
-    # the chain and are equal to or earlier than the last_justified_slot
-    # in the crystallized state.
+    #
+    # validate justified_slot and justified_block_hash
+    #
+    if attestation.justified_slot > crystallized_state.last_justified_slot:
+        raise Exception(
+            "attestation.justified_slot %s should be equal to or earlier than"
+            " crystallized_state.last_justified_slot %s" % (
+                attestation.justified_slot,
+                crystallized_state.last_justified_slot,
+            )
+        )
+
+    justified_block = active_state.chain.get_block_by_hash(attestation.justified_block_hash)
+    if justified_block is None:
+        raise Exception(
+            "justified_block_hash %s is not in the canonical chain" %
+            attestation.justified_block_hash
+        )
+    if justified_block.slot_number != attestation.justified_slot:
+        raise Exception(
+            "justified_slot %s doesn't match justified_block_hash" % attestation.justified_slot
+        )
 
     parent_hashes = get_signed_parent_hashes(
         active_state,

--- a/tests/state/conftest.py
+++ b/tests/state/conftest.py
@@ -317,6 +317,9 @@ def mock_make_attestations(keymap, config):
             print("Generating attestation for shard %s" % shard_id)
             print("Committee size %s" % len(committee_indices))
 
+            justified_slot = crystallized_state.last_justified_slot
+            justified_block_hash = active_state.chain.get_block_by_slot_number(justified_slot).hash
+
             # Create attestation
             attestation = AttestationRecord(
                 slot=block.slot_number,
@@ -324,9 +327,8 @@ def mock_make_attestations(keymap, config):
                 oblique_parent_hashes=[],
                 shard_block_hash=blake(bytes(str(shard_id), 'utf-8')),
                 attester_bitfield=get_empty_bitfield(len(committee_indices)),
-                justified_slot=crystallized_state.last_justified_slot,
-                # TODO: it's a stub for now and will be changed to the correct block hash
-                justified_block_hash=ZERO_HASH32,
+                justified_slot=justified_slot,
+                justified_block_hash=justified_block_hash,
             )
 
             # Randomly pick indices to include

--- a/tests/state/conftest.py
+++ b/tests/state/conftest.py
@@ -65,7 +65,10 @@ def bls_sign_mock(m, k):
 
 
 @pytest.fixture(autouse=True)
-def mock_bls(mocker):
+def mock_bls(mocker, request):
+    if 'noautofixt' in request.keywords:
+        return
+
     mocker.patch('beacon_chain.utils.bls.verify', side_effect=bls_verify_mock)
     mocker.patch('beacon_chain.utils.bls.sign', side_effect=bls_sign_mock)
 

--- a/tests/state/conftest.py
+++ b/tests/state/conftest.py
@@ -24,9 +24,6 @@ from beacon_chain.state.attestation_record import (
 from beacon_chain.state.block import (
     Block,
 )
-from beacon_chain.state.constants import (
-    ZERO_HASH32,
-)
 from beacon_chain.state.validator_record import (
     ValidatorRecord,
 )

--- a/tests/state/test_full_pos.py
+++ b/tests/state/test_full_pos.py
@@ -5,6 +5,9 @@ from ssz import (
     serialize,
 )
 
+from beacon_chain.state.chain import (
+    Chain,
+)
 from beacon_chain.state.state_transition import (
     compute_state_transition,
 )
@@ -29,6 +32,7 @@ def test_state_transition_integration(genesis_crystallized_state,
     c = genesis_crystallized_state
     a = genesis_active_state
     block = genesis_block
+    a.chain = Chain(head=block, blocks=[block])
     print('Generated genesis state')
     print('Crystallized state length:', len(serialize(genesis_crystallized_state)))
     print('Active state length:', len(serialize(genesis_active_state)))
@@ -111,6 +115,7 @@ def test_pos_finalization(monkeypatch,
     c = genesis_crystallized_state
     a = genesis_active_state
     block = genesis_block
+    a.chain = Chain(head=block, blocks=[block])
     expected_streak = 0
     assert c.justified_streak == expected_streak
 


### PR DESCRIPTION
Now we have a simple Chain object for tests here. This the second part of #74: Verify that the `justified_slot` and `justified_block_hash` given are in the chain and are equal to or earlier than the `last_justified_slot` in the crystallized state.
