### PR TITLE
Hash_SSZ - use Blake2b instead of Blake2s

### DIFF
--- a/hash_ssz.py
+++ b/hash_ssz.py
@@ -1,8 +1,8 @@
-from hashlib import blake2s
+from hashlib import blake2b
 from beacon_chain.state import crystallized_state as cs
 
 def hash(x):
-    return blake2s(x).digest()[:32]
+    return blake2b(x).digest()[:32]
 
 CHUNKSIZE = 128
 
@@ -37,7 +37,7 @@ def hash_ssz(val, typ=None):
         return val
     elif isinstance(typ, str) and typ[:3] == 'int':
         length = int(typ[3:])
-        assert length % 8 == 0 
+        assert length % 8 == 0
         return val.to_bytes(length // 8, 'big', signed=True)
     elif isinstance(typ, str) and typ[:4] == 'uint':
         length = int(typ[4:])

--- a/time_test.py
+++ b/time_test.py
@@ -2,10 +2,10 @@ import hash_ssz
 from beacon_chain.state import crystallized_state as cs
 from ssz import ssz
 import time
-from hashlib import blake2s
+from hashlib import blake2b
 
 def hash(x):
-    return blake2s(x).digest()[:32]
+    return blake2b(x).digest()[:32]
 
 v = cs.ValidatorRecord(pubkey=3**160, withdrawal_shard=567, withdrawal_address=b'\x35' * 20, randao_commitment=b'\x57' * 20, balance=32 * 10**18, start_dynasty=7, end_dynasty=17284)
 c = cs.CrosslinkRecord(dynasty=4, slot=12847, hash=b'\x67' * 32)


### PR DESCRIPTION
According to https://github.com/ethereum/eth2.0-specs/pull/120, tree_hash should use Blake2b instead of Blake2s. This also brings a consistent 1% perf improvement on my machine on the time_test.