### PR TITLE
Update Eth 2.0 Spec Reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # eth2.0 Beacon Chain
 [![CircleCI](https://circleci.com/gh/ethereum/beacon_chain.svg?style=svg)](https://circleci.com/gh/ethereum/beacon_chain)
-> Implements a proof of concept beacon chain for a sharded pos ethereum 2.0. Spec in progress can be found [here](https://notes.ethereum.org/s/Syj3QZSxm).
+> Implements a proof of concept beacon chain for a sharded pos ethereum 2.0. Spec in progress can be found [here](https://github.com/ethereum/eth2.0-specs).
 
 ## Installation
 Using a python3.6.* environment, run the following to install required libraries:


### PR DESCRIPTION
Reference Github instead of the deprecated page.